### PR TITLE
feat: Add AST and formatted code fixtures and test printing from AST

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Temporary files from tests
+tests/temp/ 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,84 @@
+import { parse, print } from "https://deno.land/x/swc@0.2.1/mod.ts";
+// Removed explicit type imports from swc as they are not exported
+
+// Helper function to get SWC parse options based on file path
+function getParseOptions(filePath: string): any {
+  const isTypeScript = filePath.endsWith(".ts") || filePath.endsWith(".tsx");
+  const isTsx = filePath.endsWith(".tsx");
+  const isJsx = filePath.endsWith(".jsx");
+
+  let parseOptions: any;
+
+  if (isTypeScript) {
+    parseOptions = {
+      syntax: "typescript",
+      tsx: isTsx,
+      decorators: true,
+      comments: true,
+      target: "es2022",
+      // isModule: true, // Default
+    };
+  } else {
+    parseOptions = {
+      syntax: "ecmascript",
+      jsx: isJsx,
+      comments: true,
+      target: "es2022",
+      // isModule: true, // Default
+    };
+  }
+  return parseOptions;
+}
+
+
+/**
+ * Parses the given source text using SWC, serializes the AST to JSON,
+ * and saves it to the specified JSON file path.
+ *
+ * @param sourceText The original source code.
+ * @param sourceFilePath The path to the original source file (used for context).
+ * @param astJsonPath The path where the serialized AST JSON should be saved.
+ */
+export async function generateAndSaveAst(
+  sourceText: string,
+  sourceFilePath: string,
+  astJsonPath: string,
+): Promise<void> {
+  const parseOptions = getParseOptions(sourceFilePath);
+  const originalAst = await parse(sourceText, parseOptions);
+
+  // Serialize the AST to a JSON string with indentation for readability
+  const serializedAst = JSON.stringify(originalAst, null, 2); // Added indentation
+
+  // Save the serialized AST to the specified file
+  await Deno.writeTextFile(astJsonPath, serializedAst);
+  console.log(`AST saved to: ${astJsonPath}`); // Added log
+}
+
+
+/**
+ * Reads a serialized AST from a JSON file, deserializes it,
+ * regenerates the code from the AST, and returns the regenerated source text.
+ *
+ * @param astJsonPath The path to the file containing the serialized AST JSON.
+ * @returns The regenerated source code.
+ */
+export async function printFromAstJson(
+  astJsonPath: string,
+): Promise<string> {
+  // Read the serialized AST from the file
+  const serializedAst = await Deno.readTextFile(astJsonPath);
+
+  // Deserialize the JSON string back into an AST object
+  const rehydratedAst: any = JSON.parse(serializedAst);
+
+  // Regenerate the code from the rehydrated AST
+  const printOptions = {
+    // Keep defaults for now
+  };
+
+  const { code: regeneratedSource } = await print(rehydratedAst, printOptions);
+
+  // Return the regenerated source code
+  return regeneratedSource;
+}

--- a/tests/fixtures/simple.ast.json
+++ b/tests/fixtures/simple.ast.json
@@ -1,0 +1,314 @@
+{
+  "type": "Module",
+  "span": {
+    "start": 1,
+    "end": 142,
+    "ctxt": 0
+  },
+  "body": [
+    {
+      "type": "VariableDeclaration",
+      "span": {
+        "start": 1,
+        "end": 41,
+        "ctxt": 0
+      },
+      "kind": "const",
+      "declare": false,
+      "declarations": [
+        {
+          "type": "VariableDeclarator",
+          "span": {
+            "start": 7,
+            "end": 40,
+            "ctxt": 0
+          },
+          "id": {
+            "type": "Identifier",
+            "span": {
+              "start": 7,
+              "end": 14,
+              "ctxt": 0
+            },
+            "value": "message",
+            "optional": false,
+            "typeAnnotation": {
+              "type": "TsTypeAnnotation",
+              "span": {
+                "start": 14,
+                "end": 22,
+                "ctxt": 0
+              },
+              "typeAnnotation": {
+                "type": "TsKeywordType",
+                "span": {
+                  "start": 16,
+                  "end": 22,
+                  "ctxt": 0
+                },
+                "kind": "string"
+              }
+            }
+          },
+          "init": {
+            "type": "StringLiteral",
+            "span": {
+              "start": 25,
+              "end": 40,
+              "ctxt": 0
+            },
+            "value": "Hello, world!",
+            "raw": "\"Hello, world!\""
+          },
+          "definite": false
+        }
+      ]
+    },
+    {
+      "type": "FunctionDeclaration",
+      "identifier": {
+        "type": "Identifier",
+        "span": {
+          "start": 52,
+          "end": 57,
+          "ctxt": 0
+        },
+        "value": "greet",
+        "optional": false
+      },
+      "declare": false,
+      "params": [
+        {
+          "type": "Parameter",
+          "span": {
+            "start": 58,
+            "end": 70,
+            "ctxt": 0
+          },
+          "decorators": [],
+          "pat": {
+            "type": "Identifier",
+            "span": {
+              "start": 58,
+              "end": 70,
+              "ctxt": 0
+            },
+            "value": "name",
+            "optional": false,
+            "typeAnnotation": {
+              "type": "TsTypeAnnotation",
+              "span": {
+                "start": 62,
+                "end": 70,
+                "ctxt": 0
+              },
+              "typeAnnotation": {
+                "type": "TsKeywordType",
+                "span": {
+                  "start": 64,
+                  "end": 70,
+                  "ctxt": 0
+                },
+                "kind": "string"
+              }
+            }
+          }
+        }
+      ],
+      "decorators": [],
+      "span": {
+        "start": 43,
+        "end": 126,
+        "ctxt": 0
+      },
+      "body": {
+        "type": "BlockStatement",
+        "span": {
+          "start": 78,
+          "end": 126,
+          "ctxt": 0
+        },
+        "stmts": [
+          {
+            "type": "ExpressionStatement",
+            "span": {
+              "start": 82,
+              "end": 124,
+              "ctxt": 0
+            },
+            "expression": {
+              "type": "CallExpression",
+              "span": {
+                "start": 82,
+                "end": 123,
+                "ctxt": 0
+              },
+              "callee": {
+                "type": "MemberExpression",
+                "span": {
+                  "start": 82,
+                  "end": 93,
+                  "ctxt": 0
+                },
+                "object": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 82,
+                    "end": 89,
+                    "ctxt": 0
+                  },
+                  "value": "console",
+                  "optional": false
+                },
+                "property": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 90,
+                    "end": 93,
+                    "ctxt": 0
+                  },
+                  "value": "log",
+                  "optional": false
+                }
+              },
+              "arguments": [
+                {
+                  "spread": null,
+                  "expression": {
+                    "type": "TemplateLiteral",
+                    "span": {
+                      "start": 94,
+                      "end": 122,
+                      "ctxt": 0
+                    },
+                    "expressions": [
+                      {
+                        "type": "Identifier",
+                        "span": {
+                          "start": 97,
+                          "end": 104,
+                          "ctxt": 0
+                        },
+                        "value": "message",
+                        "optional": false
+                      },
+                      {
+                        "type": "Identifier",
+                        "span": {
+                          "start": 115,
+                          "end": 119,
+                          "ctxt": 0
+                        },
+                        "value": "name",
+                        "optional": false
+                      }
+                    ],
+                    "quasis": [
+                      {
+                        "type": "TemplateElement",
+                        "span": {
+                          "start": 95,
+                          "end": 95,
+                          "ctxt": 0
+                        },
+                        "tail": false,
+                        "cooked": "",
+                        "raw": ""
+                      },
+                      {
+                        "type": "TemplateElement",
+                        "span": {
+                          "start": 105,
+                          "end": 113,
+                          "ctxt": 0
+                        },
+                        "tail": false,
+                        "cooked": " Hello, ",
+                        "raw": " Hello, "
+                      },
+                      {
+                        "type": "TemplateElement",
+                        "span": {
+                          "start": 120,
+                          "end": 121,
+                          "ctxt": 0
+                        },
+                        "tail": true,
+                        "cooked": "!",
+                        "raw": "!"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "typeArguments": null
+            }
+          }
+        ]
+      },
+      "generator": false,
+      "async": false,
+      "typeParameters": null,
+      "returnType": {
+        "type": "TsTypeAnnotation",
+        "span": {
+          "start": 71,
+          "end": 77,
+          "ctxt": 0
+        },
+        "typeAnnotation": {
+          "type": "TsKeywordType",
+          "span": {
+            "start": 73,
+            "end": 77,
+            "ctxt": 0
+          },
+          "kind": "void"
+        }
+      }
+    },
+    {
+      "type": "ExpressionStatement",
+      "span": {
+        "start": 128,
+        "end": 142,
+        "ctxt": 0
+      },
+      "expression": {
+        "type": "CallExpression",
+        "span": {
+          "start": 128,
+          "end": 141,
+          "ctxt": 0
+        },
+        "callee": {
+          "type": "Identifier",
+          "span": {
+            "start": 128,
+            "end": 133,
+            "ctxt": 0
+          },
+          "value": "greet",
+          "optional": false
+        },
+        "arguments": [
+          {
+            "spread": null,
+            "expression": {
+              "type": "StringLiteral",
+              "span": {
+                "start": 134,
+                "end": 140,
+                "ctxt": 0
+              },
+              "value": "User",
+              "raw": "\"User\""
+            }
+          }
+        ],
+        "typeArguments": null
+      }
+    }
+  ],
+  "interpreter": null
+}

--- a/tests/fixtures/simple.formatted.ts
+++ b/tests/fixtures/simple.formatted.ts
@@ -1,0 +1,5 @@
+const message: string = "Hello, world!";
+function greet(name: string): void {
+    console.log(`${message} Hello, ${name}!`);
+}
+greet("User");

--- a/tests/main_test.ts
+++ b/tests/main_test.ts
@@ -81,6 +81,20 @@ Deno.test("Complex TS fixture should be idempotent via saved AST", async (t) => 
   await Deno.remove(astJsonPath2).catch(() => {});
 });
 
+Deno.test("Print from saved simple.ast.json fixture matches expected formatted output", async () => {
+  const fixtureAstPath = "./tests/fixtures/simple.ast.json";
+  const expectedFormattedPath = "./tests/fixtures/simple.formatted.ts";
+
+  const regeneratedSource = await printFromAstJson(fixtureAstPath);
+  const expectedSource = await Deno.readTextFile(expectedFormattedPath);
+
+  assertEquals(
+    regeneratedSource,
+    expectedSource,
+    "Printing from the saved AST fixture should match the pre-formatted fixture file.",
+  );
+});
+
 // // Run cleanup after all tests (alternative to signal listener)
 // // Note: This might not run if tests exit prematurely.
 // globalThis.addEventListener("unload", async () => {

--- a/tests/main_test.ts
+++ b/tests/main_test.ts
@@ -1,0 +1,88 @@
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { ensureDir } from "https://deno.land/std@0.224.0/fs/ensure_dir.ts";
+// Import the new functions
+import { generateAndSaveAst, printFromAstJson } from "../src/main.ts";
+
+const TEMP_DIR = "./tests/temp";
+
+// Helper to clean up temp files after tests
+async function cleanupTempDir() {
+  try {
+    await Deno.remove(TEMP_DIR, { recursive: true });
+    console.log(`Cleaned up temp directory: ${TEMP_DIR}`);
+  } catch (error) {
+    if (!(error instanceof Deno.errors.NotFound)) {
+      console.error(`Error cleaning up temp directory: ${error}`);
+    }
+  }
+}
+
+// Ensure temp dir exists before running tests and clean up after
+await ensureDir(TEMP_DIR);
+Deno.addSignalListener("SIGINT", async () => {
+  await cleanupTempDir();
+  Deno.exit();
+});
+
+
+Deno.test("SWC formatting should be idempotent via saved AST", async (t) => {
+  const fixturePath = "./tests/fixtures/simple.ts";
+  const astJsonPath1 = `${TEMP_DIR}/simple.ast.json`;
+  const astJsonPath2 = `${TEMP_DIR}/simple_pass2.ast.json`;
+
+  await t.step("Generate, save, load, print twice and check idempotency", async () => {
+    // First pass: src -> save AST -> print
+    const originalSource = await Deno.readTextFile(fixturePath);
+    await generateAndSaveAst(originalSource, fixturePath, astJsonPath1);
+    const regeneratedSource1 = await printFromAstJson(astJsonPath1);
+
+    // Second pass: regenerated1 -> save AST -> print
+    await generateAndSaveAst(regeneratedSource1, fixturePath, astJsonPath2);
+    const regeneratedSource2 = await printFromAstJson(astJsonPath2);
+
+    // Assert idempotency
+    assertEquals(
+      regeneratedSource2,
+      regeneratedSource1,
+      "Printing from saved AST twice should produce identical output.",
+    );
+  });
+
+  // Clean up specific files for this test
+  await Deno.remove(astJsonPath1).catch(() => {});
+  await Deno.remove(astJsonPath2).catch(() => {});
+});
+
+Deno.test("Complex TS fixture should be idempotent via saved AST", async (t) => {
+  const fixturePath = "./tests/fixtures/complex.ts";
+  const astJsonPath1 = `${TEMP_DIR}/complex.ast.json`;
+  const astJsonPath2 = `${TEMP_DIR}/complex_pass2.ast.json`;
+
+  await t.step("Generate, save, load, print twice and check idempotency", async () => {
+    // First pass: src -> save AST -> print
+    const originalSource = await Deno.readTextFile(fixturePath);
+    await generateAndSaveAst(originalSource, fixturePath, astJsonPath1);
+    const regeneratedSource1 = await printFromAstJson(astJsonPath1);
+
+    // Second pass: regenerated1 -> save AST -> print
+    await generateAndSaveAst(regeneratedSource1, fixturePath, astJsonPath2);
+    const regeneratedSource2 = await printFromAstJson(astJsonPath2);
+
+    // Assert idempotency
+    assertEquals(
+      regeneratedSource2,
+      regeneratedSource1,
+      "Printing complex fixture from saved AST twice should produce identical output.",
+    );
+  });
+
+  // Clean up specific files for this test
+  await Deno.remove(astJsonPath1).catch(() => {});
+  await Deno.remove(astJsonPath2).catch(() => {});
+});
+
+// // Run cleanup after all tests (alternative to signal listener)
+// // Note: This might not run if tests exit prematurely.
+// globalThis.addEventListener("unload", async () => {
+//   await cleanupTempDir();
+// }); 


### PR DESCRIPTION
Adds fixtures for serialized AST and expected formatted code. Includes tests for validating the print-from-AST functionality.

## Summary by Sourcery

Add AST serialization and printing functionality for TypeScript files using SWC

New Features:
- Implement functions to generate, save, and print AST from TypeScript source code
- Add ability to serialize and deserialize Abstract Syntax Trees (AST) for TypeScript files

Enhancements:
- Support parsing and printing for both TypeScript and JavaScript files
- Add flexible parsing options based on file extensions

Tests:
- Create comprehensive test suite to validate AST serialization and printing
- Implement idempotency tests for AST generation and printing
- Add tests to ensure formatted code matches expected output